### PR TITLE
fix nested template problem in quicksort

### DIFF
--- a/quicksort/main.cc
+++ b/quicksort/main.cc
@@ -92,10 +92,10 @@ template <> struct quicksort<list<>>
 template <int x, int ...xs> struct quicksort<list<x, xs...>>
 {
     template <int lhs>
-    using lep = typename le<x>::value<lhs>;
+    using lep = typename le<x>::template value<lhs>;
     
     template <int lhs>
-    using gtp = typename gt<x>::value<lhs>;
+    using gtp = typename gt<x>::template value<lhs>;
     
     using value = typename concat<
         typename quicksort<typename filter<lep, list<xs...>>::value>::value,


### PR DESCRIPTION
When I use gcc and clang in Ubuntu to compile this **main.cc** 
In gcc , I get compile error started with
```
.\main.cc:95:38: error: expected ';' before '<' token
     using lep = typename le<x>::value<lhs>;
                                      ^
                                      ;
.\main.cc:98:38: error: expected ';' before '<' token
     using gtp = typename gt<x>::value<lhs>;
                                      ^
```
And in clang , I get compile error 
```
te.cpp:95:33: error: use 'template' keyword to treat 'value' as a dependent template name
    using lep = typename le<x>::value<lhs>;
                                ^
                                template 
te.cpp:98:33: error: use 'template' keyword to treat 'value' as a dependent template name
    using gtp = typename gt<x>::value<lhs>;
                                ^
                                template 
2 errors generated.
```
It seems like the compiler can not tell the '<>' after a '<>'  in this specific condition.
Check the familiar problem here https://stackoverflow.com/questions/3786360/confusing-template-error
I do not know what compiler you are using , but for the convience of others to study , I hope you can take the PR